### PR TITLE
Removes index from region object

### DIFF
--- a/getRegions/index.js
+++ b/getRegions/index.js
@@ -34,7 +34,6 @@ const getRegions = (numberOfSides) => {
 
   for (let i = 0; i < numberOfSides; i += 1) {
     regions.push({
-      region: i,
       max: (i + 1) * ((2 * Math.PI) / numberOfSides),
       min: i * ((2 * Math.PI) / numberOfSides),
     });

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "regional",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "regional",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regional",
-  "version": "0.2.2",
+  "version": "0.2.3",
   "description": "Given two points and a range of regions, determines which region the second point is in with relation to the first",
   "main": "index.js",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "regional",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "description": "Given two points and a range of regions, determines which region the second point is in with relation to the first",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
Originally I had the index in the region object to make it easier to find the index. But I totally forgot about `Array#findIndex`. So that kind of makes keeping the index in the object redundant.